### PR TITLE
enh: set restart to always instead of on failure

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,6 +34,7 @@ services:
   #   # https://github.com/containrrr/watchtower
   #   image: containrrr/watchtower
   #   command: --scope goodkarmakit
+  #   restart: always
   #   volumes:
   #     # Security warning: in order to apply updates, it needs admin access to administer *all* docker containers on the host system
   #     - /var/run/docker.sock:/var/run/docker.sock
@@ -59,7 +60,7 @@ services:
      - ./data/tor:/var/lib/tor   # optional to store temp config between restarts
     cpus: 2                        # tune according to your system & preferences
     mem_limit: 2048m               # tune according to your system & preferences
-    restart: on-failure
+    restart: always
     labels:
       - "com.centurylinklabs.watchtower.scope=goodkarmakit"
 
@@ -85,7 +86,7 @@ services:
       - EXT_PORT=CHANGEME
     cpus: 2                        # tune according to your system & preferences
     mem_limit: 2048m               # tune according to your system & preferences
-    restart: on-failure
+    restart: always
     labels:
       - "com.centurylinklabs.watchtower.scope=goodkarmakit"
 
@@ -106,7 +107,7 @@ services:
       - ./data/boinc:/config
     cpus: 4                        # tune according to your system & preferences
     mem_limit: 4096m               # tune according to your system & preferences
-    restart: on-failure
+    restart: always
     labels:
       - "com.centurylinklabs.watchtower.scope=goodkarmakit"
 
@@ -123,7 +124,7 @@ services:
       - ./data/foldingathome:/config
     cpus: 4                        # tune according to your system & preferences
     mem_limit: 4096m               # tune according to your system & preferences
-    restart: on-failure
+    restart: always
     labels:
       - "com.centurylinklabs.watchtower.scope=goodkarmakit"
 
@@ -147,7 +148,7 @@ services:
       - CONCURRENT_ITEMS=3
     cpus: 3
     mem_limit: 3072m
-    restart: on-failure
+    restart: always
     labels:
       - "com.centurylinklabs.watchtower.scope=goodkarmakit"
 
@@ -166,7 +167,7 @@ services:
   #     - ./data/zimfarm:/data/zimfarm
   #   cpus: 3
   #   mem_limit: 3072m
-  #   restart: on-failure
+  #   restart: always
   #   labels:
   #     - "com.centurylinklabs.watchtower.scope=goodkarmakit"
 
@@ -185,7 +186,7 @@ services:
       - ./data/kiwix:/data:ro
     cpus: 1
     mem_limit: 768m
-    restart: on-failure
+    restart: always
     labels:
       - "com.centurylinklabs.watchtower.scope=goodkarmakit"
 
@@ -206,7 +207,7 @@ services:
       - ./data/archivebox:/data
     cpus: 3
     mem_limit: 3072m
-    restart: on-failure
+    restart: always
     labels:
       - "com.centurylinklabs.watchtower.scope=goodkarmakit"
 
@@ -225,7 +226,7 @@ services:
       - ./data/pywb:/webarchive
     cpus: 3
     mem_limit: 3072m
-    restart: on-failure
+    restart: always
     labels:
       - "com.centurylinklabs.watchtower.scope=goodkarmakit"
 
@@ -248,7 +249,7 @@ services:
       - ./data/ipfs:/data/ipfs
     cpus: 2
     mem_limit: 2048m
-    restart: on-failure
+    restart: always
     labels:
       - "com.centurylinklabs.watchtower.scope=goodkarmakit"
 
@@ -274,7 +275,7 @@ services:
       - ./data/storj/identity/storagenode:/app/identity
     cpus: 2
     mem_limit: 2048m
-    restart: on-failure
+    restart: always
     labels:
       - "com.centurylinklabs.watchtower.scope=goodkarmakit"
 
@@ -296,7 +297,7 @@ services:
         - ./data/transmission:/config
     cpus: 2
     mem_limit: 2048m
-    restart: on-failure
+    restart: always
     labels:
       - "com.centurylinklabs.watchtower.scope=goodkarmakit"
 


### PR DESCRIPTION
Signed-off-by: thiswillbeyourgithub <26625900+thiswillbeyourgithub@users.noreply.github.com>

not sure why you would set it to on-failure. the way I see it it makes it harder to maintain a storj node for ewample no?
