### PR TITLE
fix: broken link because of missing parentheses and newline

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,8 @@ Notes: Does not run a guard/exit node, only a [middle relay](https://community.t
 
 > Run a relay node for the i2p routing network (similar to Tor). (501(c)(3) US nonprofit)
 
-[https://geti2p.net/en/](https://geti2p.net/en/
+[https://geti2p.net/en/](https://geti2p.net/en/)
+
 [https://geti2p.net/en/download/docker](https://geti2p.net/en/download/docker)
 
 <br/>


### PR DESCRIPTION
Signed-off-by: thiswillbeyourgithub <26625900+thiswillbeyourgithub@users.noreply.github.com>
